### PR TITLE
Added condition to docs pipeline to disable it for now

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
   all:
     name: all
     runs-on: ubuntu-latest
+    # Currently disabled. Remove the `if: false` condition to enable when needed.
+    if: false
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Disabling Docs pipeline since it won't be used for now and therefore there's no need for it to be called whenever there's a new merge. Can be reactivated by just deleting the condition added